### PR TITLE
fixed TrackRequest()'s id and duration.

### DIFF
--- a/appinsights/bond.go
+++ b/appinsights/bond.go
@@ -1,24 +1,16 @@
 package appinsights
 
-type Domain interface {
+type Data struct {
+	BaseType string      `json:"baseType"`
+	BaseData interface{} `json:"baseData"`
 }
 
-type domain struct {
-	Ver        int               `json:"ver"`
-	Properties map[string]string `json:"properties"`
-}
-
-type data struct {
-	BaseType string `json:"baseType"`
-	BaseData Domain `json:"baseData"`
-}
-
-type envelope struct {
+type Envelope struct {
 	Name string            `json:"name"`
 	Time string            `json:"time"`
 	IKey string            `json:"iKey"`
 	Tags map[string]string `json:"tags"`
-	Data *data             `json:"data"`
+	Data Data              `json:"data"`
 }
 
 type DataPointType int
@@ -33,18 +25,20 @@ type DataPoint struct {
 	Kind   DataPointType `json:"kind"`
 	Value  float32       `json:"value"`
 	Count  int           `json:"count"`
-	min    float32       `json:"min"`
-	max    float32       `json:"max"`
-	stdDev float32       `json:"stdDev"`
+	Min    float32       `json:"min"`
+	Max    float32       `json:"max"`
+	StdDev float32       `json:"stdDev"`
 }
 
-type metricData struct {
-	domain
-	Metrics []*DataPoint `json:"metrics"`
+type MetricData struct {
+	Ver        int               `json:"ver"`
+	Properties map[string]string `json:"properties"`
+	Metrics    []*DataPoint      `json:"metrics"`
 }
 
-type eventData struct {
-	domain
+type EventData struct {
+	Ver          int                `json:"ver"`
+	Properties   map[string]string  `json:"properties"`
 	Name         string             `json:"name"`
 	Measurements map[string]float32 `json:"measurements"`
 }
@@ -59,22 +53,24 @@ const (
 	Critical
 )
 
-type messageData struct {
-	domain
-	Message       string        `json:"message"`
-	SeverityLevel SeverityLevel `json:"severityLevel"`
+type MessageData struct {
+	Ver           int               `json:"ver"`
+	Properties    map[string]string `json:"properties"`
+	Message       string            `json:"message"`
+	SeverityLevel SeverityLevel     `json:"severityLevel"`
 }
 
-type requestData struct {
-	domain
+type RequestData struct {
+	Ver          int                `json:"ver"`
+	Properties   map[string]string  `json:"properties"`
 	Id           string             `json:"id"`
 	Name         string             `json:"name"`
 	StartTime    string             `json:"startTime"` // yyyy-mm-ddThh:mm:ss.fffffff-hh:mm
 	Duration     string             `json:"duration"`  // d:hh:mm:ss.fffffff
 	ResponseCode string             `json:"responseCode"`
 	Success      bool               `json:"success"`
-	httpMethod   string             `json:"httpMethod"`
-	url          string             `json:"url"`
+	HttpMethod   string             `json:"httpMethod"`
+	Url          string             `json:"url"`
 	Measurements map[string]float32 `json:"measurements"`
 }
 

--- a/appinsights/bond.go
+++ b/appinsights/bond.go
@@ -74,6 +74,42 @@ type RequestData struct {
 	Measurements map[string]float32 `json:"measurements"`
 }
 
+type DependencyKind int
+
+const (
+	SQL DependencyKind = iota
+	Http
+	Other
+)
+
+type DependencySourceType int
+
+const (
+	Undefined DependencySourceType = iota
+	Aic
+	Apmc
+)
+
+type RemoteDependencyData struct {
+	Ver              int                  `json:"ver"`
+	Id               string               `json:"id"`
+	Name             string               `json:"name"`
+	ResultCode       int                  `json:"resultCode"`
+	CommandName      string               `json:"commandName"`
+	Kind             DataPointType        `json:"kind"`
+	Duration         string               `json:"duration"`
+	Count            int                  `json:"count"`
+	Min              float32              `json:"min"`
+	Max              float32              `json:"max"`
+	StdDev           float32              `json:"stdDev"`
+	Type             string               `json:"type"`
+	DependencyKind   DependencyKind       `json:"-"` // omitted according to Java reference
+	Success          bool                 `json:"success"`
+	Async            bool                 `json:"async"`
+	DependencySource DependencySourceType `json:"dependencySource"`
+	Properties       map[string]string    `json:"properties"`
+}
+
 type ContextTagKeys string
 
 const (

--- a/appinsights/bond_test.go
+++ b/appinsights/bond_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestMessageData(t *testing.T) {
 	testMessage := "test"
 
-	messageData := &messageData{
+	messageData := &MessageData{
 		Message: testMessage,
 	}
 

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -55,8 +55,14 @@ func (tc *TelemetryClient) TrackMetric(name string, value float32) {
 func (tc *TelemetryClient) TrackTrace(
 	level SeverityLevel,
 	message string,
-	properties map[string]string) {
-	tc.Track(NewTraceTelemetry(message, properties, level))
+	properties map[string]string,
+	alterTelementryContext func(*TelemetryContext)) {
+
+	tc.Track(NewTraceTelemetry(
+		message,
+		properties,
+		level,
+		alterTelementryContext))
 }
 
 func (tc *TelemetryClient) TrackRequest(
@@ -67,7 +73,9 @@ func (tc *TelemetryClient) TrackRequest(
 	httpMethod string,
 	url string,
 	responseCode string,
-	success bool) {
+	success bool,
+	properties map[string]string,
+	alterTelementryContext func(*TelemetryContext)) {
 
 	tc.Track(NewRequestTelemetry(
 		id,
@@ -77,7 +85,9 @@ func (tc *TelemetryClient) TrackRequest(
 		httpMethod,
 		url,
 		responseCode,
-		success))
+		success,
+		properties,
+		alterTelementryContext))
 }
 
 func (tc *TelemetryClient) TrackRemoteDependency(

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -4,7 +4,7 @@ import "time"
 
 type TelemetryClient struct {
 	TelemetryConfiguration TelemetryConfiguration
-	channel                TelemetryChannel
+	Channel                TelemetryChannel
 	Context                TelemetryContext
 	IsEnabled              bool
 }
@@ -13,7 +13,7 @@ func NewTelemetryClient(iKey string) TelemetryClient {
 	config := NewTelemetryConfiguration(iKey)
 	return TelemetryClient{
 		TelemetryConfiguration: config,
-		channel:                NewInMemoryChannel(config.EndpointUrl),
+		Channel:                NewInMemoryChannel(config.EndpointUrl),
 		Context:                NewClientTelemetryContext(),
 		IsEnabled:              true,
 	}
@@ -41,7 +41,7 @@ func (tc *TelemetryClient) Track(item Telemetry) {
 		}
 	}
 
-	tc.channel.Send(item)
+	tc.Channel.Send(item)
 }
 
 func (tc *TelemetryClient) TrackEvent(name string) {

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -76,3 +76,42 @@ func (tc *TelemetryClient) TrackRequest(
 		responseCode,
 		success))
 }
+
+func (tc *TelemetryClient) TrackRemoteDependency(
+	id string,
+	name string,
+	resultCode int,
+	commandName string,
+	kind DataPointType,
+	duration time.Duration,
+	count int,
+	min float32,
+	max float32,
+	stdDev float32,
+	theType string,
+	dependencyKind DependencyKind,
+	success bool,
+	async bool,
+	dependencySource DependencySourceType,
+	properties map[string]string,
+	alterTelementryContext func(*TelemetryContext)) {
+
+	tc.Track(NewRemoteDependencyData(
+		id,
+		name,
+		resultCode,
+		commandName,
+		kind,
+		duration,
+		count,
+		min,
+		max,
+		stdDev,
+		theType,
+		dependencyKind,
+		success,
+		async,
+		dependencySource,
+		properties,
+		alterTelementryContext))
+}

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -56,6 +56,23 @@ func (tc *TelemetryClient) TrackTrace(message string) {
 	tc.Track(NewTraceTelemetry(message, Information))
 }
 
-func (tc *TelemetryClient) TrackRequest(name string, timestamp time.Time, duration time.Duration, responseCode string, success bool) {
-	tc.Track(NewRequestTelemetry(name, timestamp, duration, responseCode, success))
+func (tc *TelemetryClient) TrackRequest(
+	id string,
+	name string,
+	timestamp time.Time,
+	duration time.Duration,
+	httpMethod string,
+	url string,
+	responseCode string,
+	success bool) {
+
+	tc.Track(NewRequestTelemetry(
+		id,
+		name,
+		timestamp,
+		duration,
+		httpMethod,
+		url,
+		responseCode,
+		success))
 }

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -52,8 +52,11 @@ func (tc *TelemetryClient) TrackMetric(name string, value float32) {
 	tc.Track(NewMetricTelemetry(name, value))
 }
 
-func (tc *TelemetryClient) TrackTrace(message string) {
-	tc.Track(NewTraceTelemetry(message, Information))
+func (tc *TelemetryClient) TrackTrace(
+	level SeverityLevel,
+	message string,
+	properties map[string]string) {
+	tc.Track(NewTraceTelemetry(message, properties, level))
 }
 
 func (tc *TelemetryClient) TrackRequest(

--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -2,123 +2,60 @@ package appinsights
 
 import "time"
 
-type TelemetryClient interface {
-	Context() TelemetryContext
-	InstrumentationKey() string
-	IsEnabled() bool
-	SetIsEnabled(bool)
-	Track(Telemetry)
-	TrackEvent(string)
-	TrackEventTelemetry(*EventTelemetry)
-	TrackMetric(string, float32)
-	TrackMetricTelemetry(*MetricTelemetry)
-	TrackTrace(string)
-	TrackTraceTelemetry(*TraceTelemetry)
-	TrackRequest(string, time.Time, time.Duration, string, bool)
-	TrackRequestTelemetry(*RequestTelemetry)
-}
-
-type telemetryClient struct {
-	TelemetryConfiguration *TelemetryConfiguration
+type TelemetryClient struct {
+	TelemetryConfiguration TelemetryConfiguration
 	channel                TelemetryChannel
-	context                TelemetryContext
-	isEnabled              bool
+	Context                TelemetryContext
+	IsEnabled              bool
 }
 
 func NewTelemetryClient(iKey string) TelemetryClient {
 	config := NewTelemetryConfiguration(iKey)
-	channel := NewInMemoryChannel(config.EndpointUrl)
-	context := NewClientTelemetryContext()
-	return &telemetryClient{
+	return TelemetryClient{
 		TelemetryConfiguration: config,
-		channel:                channel,
-		context:                context,
-		isEnabled:              true,
+		channel:                NewInMemoryChannel(config.EndpointUrl),
+		Context:                NewClientTelemetryContext(),
+		IsEnabled:              true,
 	}
 }
 
-func (tc *telemetryClient) Context() TelemetryContext {
-	return tc.context
-}
-
-func (tc *telemetryClient) InstrumentationKey() string {
+func (tc TelemetryClient) InstrumentationKey() string {
 	return tc.TelemetryConfiguration.InstrumentationKey
 }
 
-func (tc *telemetryClient) IsEnabled() bool {
-	return tc.isEnabled
-}
-
-func (tc *telemetryClient) SetIsEnabled(isEnabled bool) {
-	tc.isEnabled = isEnabled
-}
-
-func (tc *telemetryClient) Track(item Telemetry) {
-	if tc.isEnabled {
-		iKey := tc.context.InstrumentationKey()
-		if len(iKey) == 0 {
-			iKey = tc.TelemetryConfiguration.InstrumentationKey
-		}
-
-		itemContext := item.Context().(*telemetryContext)
-		itemContext.iKey = iKey
-
-		clientContext := tc.context.(*telemetryContext)
-
-		for tagkey, tagval := range clientContext.tags {
-			if itemContext.tags[tagkey] == "" {
-				itemContext.tags[tagkey] = tagval
-			}
-		}
-
-		tc.channel.Send(item)
+func (tc *TelemetryClient) Track(item Telemetry) {
+	if !tc.IsEnabled {
+		return
 	}
+
+	iKey := tc.Context.InstrumentationKey
+	if len(iKey) == 0 {
+		iKey = tc.TelemetryConfiguration.InstrumentationKey
+	}
+
+	item.Context.InstrumentationKey = iKey
+
+	for tagkey, tagval := range tc.Context.Tags {
+		if item.Context.Tags[tagkey] == "" {
+			item.Context.Tags[tagkey] = tagval
+		}
+	}
+
+	tc.channel.Send(item)
 }
 
-func (tc *telemetryClient) TrackEvent(name string) {
-	item := NewEventTelemetry(name)
-	tc.TrackEventTelemetry(item)
+func (tc *TelemetryClient) TrackEvent(name string) {
+	tc.Track(NewEventTelemetry(name))
 }
 
-func (tc *telemetryClient) TrackEventTelemetry(event *EventTelemetry) {
-	var item Telemetry
-	item = event
-
-	tc.Track(item)
+func (tc *TelemetryClient) TrackMetric(name string, value float32) {
+	tc.Track(NewMetricTelemetry(name, value))
 }
 
-func (tc *telemetryClient) TrackMetric(name string, value float32) {
-	item := NewMetricTelemetry(name, value)
-	tc.TrackMetricTelemetry(item)
+func (tc *TelemetryClient) TrackTrace(message string) {
+	tc.Track(NewTraceTelemetry(message, Information))
 }
 
-func (tc *telemetryClient) TrackMetricTelemetry(metric *MetricTelemetry) {
-	var item Telemetry
-	item = metric
-
-	tc.Track(item)
-}
-
-func (tc *telemetryClient) TrackTrace(message string) {
-	item := NewTraceTelemetry(message, Information)
-	tc.TrackTraceTelemetry(item)
-}
-
-func (tc *telemetryClient) TrackTraceTelemetry(trace *TraceTelemetry) {
-	var item Telemetry
-	item = trace
-
-	tc.Track(item)
-}
-
-func (tc *telemetryClient) TrackRequest(name string, timestamp time.Time, duration time.Duration, responseCode string, success bool) {
-	item := NewRequestTelemetry(name, timestamp, duration, responseCode, success)
-	tc.TrackRequestTelemetry(item)
-}
-
-func (tc *telemetryClient) TrackRequestTelemetry(request *RequestTelemetry) {
-	var item Telemetry
-	item = request
-
-	tc.Track(item)
+func (tc *TelemetryClient) TrackRequest(name string, timestamp time.Time, duration time.Duration, responseCode string, success bool) {
+	tc.Track(NewRequestTelemetry(name, timestamp, duration, responseCode, success))
 }

--- a/appinsights/client_test.go
+++ b/appinsights/client_test.go
@@ -5,6 +5,6 @@ import "testing"
 func TestClientBurstPerformance(t *testing.T) {
 	telemetryClient := NewTelemetryClient("")
 	for i := 0; i < 1000000; i++ {
-		telemetryClient.TrackTrace(Information, "A message", nil)
+		telemetryClient.TrackTrace(Information, "A message", nil, func(*TelemetryContext) {})
 	}
 }

--- a/appinsights/client_test.go
+++ b/appinsights/client_test.go
@@ -5,6 +5,6 @@ import "testing"
 func TestClientBurstPerformance(t *testing.T) {
 	telemetryClient := NewTelemetryClient("")
 	for i := 0; i < 1000000; i++ {
-		telemetryClient.TrackTrace("A message")
+		telemetryClient.TrackTrace(Information, "A message", nil)
 	}
 }

--- a/appinsights/configuration.go
+++ b/appinsights/configuration.go
@@ -5,8 +5,8 @@ type TelemetryConfiguration struct {
 	EndpointUrl        string
 }
 
-func NewTelemetryConfiguration(instrumentationKey string) *TelemetryConfiguration {
-	return &TelemetryConfiguration{
+func NewTelemetryConfiguration(instrumentationKey string) TelemetryConfiguration {
+	return TelemetryConfiguration{
 		InstrumentationKey: instrumentationKey,
 		EndpointUrl:        "https://dc.services.visualstudio.com/v2/track",
 	}

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -1,6 +1,10 @@
 package appinsights
 
-import "time"
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+	"time"
+)
 
 type Telemetry interface {
 	Timestamp() time.Time
@@ -145,10 +149,30 @@ type RequestTelemetry struct {
 
 func NewRequestTelemetry(name string, timestamp time.Time, duration time.Duration, responseCode string, success bool) *RequestTelemetry {
 	now := time.Now()
+
+	var (
+		refHours        = int(duration.Hours())
+		refMinutes      = int(duration.Minutes())
+		refSeconds      = int(duration.Seconds())
+		refMilliPlusOne = int(duration.Nanoseconds() / 1e3)
+		days            = refHours / 24
+		hours           = refHours - days*24
+		minutes         = refMinutes - refHours*60
+		seconds         = refSeconds - refMinutes*60
+		milliPlusOne    = refMilliPlusOne - refSeconds*1e6
+	)
+	durationString := fmt.Sprintf("%02d.%02d:%02d:%02d.%04d",
+		days,
+		hours,
+		minutes,
+		seconds,
+		milliPlusOne)
+
 	data := &requestData{
+		Id:           uuid.NewV4().String(),
 		Name:         name,
 		StartTime:    timestamp.Format(time.RFC3339Nano),
-		Duration:     duration.String(),
+		Duration:     durationString,
 		ResponseCode: responseCode,
 		Success:      success,
 	}

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -2,205 +2,88 @@ package appinsights
 
 import (
 	"fmt"
-	"github.com/satori/go.uuid"
 	"time"
+
+	"github.com/satori/go.uuid"
 )
 
-type Telemetry interface {
-	Timestamp() time.Time
-	Context() TelemetryContext
-	baseTypeName() string
-	baseData() Domain
+type Telemetry struct {
+	Timestamp time.Time
+	Context   TelemetryContext
+	TypeName  string
+	Data      interface{}
 }
 
-type BaseTelemetry struct {
-	timestamp time.Time
-	context   TelemetryContext
+func NewTraceTelemetry(message string, severityLevel SeverityLevel) Telemetry {
+	return Telemetry{
+		Timestamp: time.Now(),
+		Context:   NewItemTelemetryContext(),
+		TypeName:  "Message",
+		Data: &MessageData{
+			Message: message,
+			Ver:     2}}
 }
 
-type TraceTelemetry struct {
-	BaseTelemetry
-	data *messageData
+func NewEventTelemetry(name string) Telemetry {
+	return Telemetry{
+		Timestamp: time.Now(),
+		Context:   NewItemTelemetryContext(),
+		TypeName:  "Event",
+		Data: &EventData{
+			Name: name,
+			Ver:  2}}
 }
 
-func NewTraceTelemetry(message string, severityLevel SeverityLevel) *TraceTelemetry {
-	now := time.Now()
-	data := &messageData{
-		Message: message,
-	}
-
-	data.Ver = 2
-
-	item := &TraceTelemetry{
-		data: data,
-	}
-
-	item.timestamp = now
-	item.context = NewItemTelemetryContext()
-
-	return item
+func NewMetricTelemetry(name string, value float32) Telemetry {
+	return Telemetry{
+		Timestamp: time.Now(),
+		Context:   NewItemTelemetryContext(),
+		TypeName:  "Metric",
+		Data: &MetricData{
+			Metrics: []*DataPoint{&DataPoint{
+				Name:  name,
+				Value: value,
+				Count: 1}},
+			Ver: 2}}
 }
 
-func (item *TraceTelemetry) Timestamp() time.Time {
-	return item.timestamp
+func NewRequestTelemetry(
+	name string,
+	timestamp time.Time,
+	duration time.Duration,
+	responseCode string,
+	success bool) Telemetry {
+
+	return Telemetry{
+		Timestamp: time.Now(),
+		Context:   NewItemTelemetryContext(),
+		TypeName:  "Request",
+		Data: &RequestData{
+			Id:           uuid.NewV4().String(),
+			Name:         name,
+			StartTime:    timestamp.Format(time.RFC3339Nano),
+			Duration:     formatDuration(duration),
+			ResponseCode: responseCode,
+			Success:      success,
+			Ver:          2}}
 }
 
-func (item *TraceTelemetry) Context() TelemetryContext {
-	return item.context
-}
-
-func (item *TraceTelemetry) baseTypeName() string {
-	return "Message"
-}
-
-func (item *TraceTelemetry) baseData() Domain {
-	return item.data
-}
-
-type EventTelemetry struct {
-	BaseTelemetry
-	data *eventData
-}
-
-func NewEventTelemetry(name string) *EventTelemetry {
-	now := time.Now()
-	data := &eventData{
-		Name: name,
-	}
-
-	data.Ver = 2
-
-	item := &EventTelemetry{
-		data: data,
-	}
-
-	item.timestamp = now
-	item.context = NewItemTelemetryContext()
-
-	return item
-}
-
-func (item *EventTelemetry) Timestamp() time.Time {
-	return item.timestamp
-}
-
-func (item *EventTelemetry) Context() TelemetryContext {
-	return item.context
-}
-
-func (item *EventTelemetry) baseTypeName() string {
-	return "Event"
-}
-
-func (item *EventTelemetry) baseData() Domain {
-	return item.data
-}
-
-type MetricTelemetry struct {
-	BaseTelemetry
-	data *metricData
-}
-
-func NewMetricTelemetry(name string, value float32) *MetricTelemetry {
-	now := time.Now()
-	metric := &DataPoint{
-		Name:  name,
-		Value: value,
-		Count: 1,
-	}
-
-	data := &metricData{
-		Metrics: make([]*DataPoint, 1),
-	}
-
-	data.Ver = 2
-	data.Metrics[0] = metric
-
-	item := &MetricTelemetry{
-		data: data,
-	}
-
-	item.timestamp = now
-	item.context = NewItemTelemetryContext()
-
-	return item
-}
-
-func (item *MetricTelemetry) Timestamp() time.Time {
-	return item.timestamp
-}
-
-func (item *MetricTelemetry) Context() TelemetryContext {
-	return item.context
-}
-
-func (item *MetricTelemetry) baseTypeName() string {
-	return "Metric"
-}
-
-func (item *MetricTelemetry) baseData() Domain {
-	return item.data
-}
-
-type RequestTelemetry struct {
-	BaseTelemetry
-	data *requestData
-}
-
-func NewRequestTelemetry(name string, timestamp time.Time, duration time.Duration, responseCode string, success bool) *RequestTelemetry {
-	now := time.Now()
-
+func formatDuration(duration time.Duration) string {
 	var (
-		refHours        = int(duration.Hours())
-		refMinutes      = int(duration.Minutes())
-		refSeconds      = int(duration.Seconds())
-		refMilliPlusOne = int(duration.Nanoseconds() / 1e3)
-		days            = refHours / 24
-		hours           = refHours - days*24
-		minutes         = refMinutes - refHours*60
-		seconds         = refSeconds - refMinutes*60
-		milliPlusOne    = refMilliPlusOne - refSeconds*1e6
+		refHours   = int(duration.Hours())
+		refMinutes = int(duration.Minutes())
+		refSeconds = int(duration.Seconds())
+		refMilli   = int(duration.Nanoseconds() / 1e3)
+		days       = refHours / 24
+		hours      = refHours - days*24
+		minutes    = refMinutes - refHours*60
+		seconds    = refSeconds - refMinutes*60
+		milli      = refMilli - refSeconds*1e6
 	)
-	durationString := fmt.Sprintf("%02d.%02d:%02d:%02d.%04d",
+	return fmt.Sprintf("%02d.%02d:%02d:%02d.%04d",
 		days,
 		hours,
 		minutes,
 		seconds,
-		milliPlusOne)
-
-	data := &requestData{
-		Id:           uuid.NewV4().String(),
-		Name:         name,
-		StartTime:    timestamp.Format(time.RFC3339Nano),
-		Duration:     durationString,
-		ResponseCode: responseCode,
-		Success:      success,
-	}
-
-	data.Ver = 2
-
-	item := &RequestTelemetry{
-		data: data,
-	}
-
-	item.timestamp = now
-	item.context = NewItemTelemetryContext()
-
-	return item
-}
-
-func (item *RequestTelemetry) Timestamp() time.Time {
-	return item.timestamp
-}
-
-func (item *RequestTelemetry) Context() TelemetryContext {
-	return item.context
-}
-
-func (item *RequestTelemetry) baseTypeName() string {
-	return "Request"
-}
-
-func (item *RequestTelemetry) baseData() Domain {
-	return item.data
+		milli)
 }

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -3,8 +3,6 @@ package appinsights
 import (
 	"fmt"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
 type Telemetry struct {
@@ -48,9 +46,12 @@ func NewMetricTelemetry(name string, value float32) Telemetry {
 }
 
 func NewRequestTelemetry(
+	id string,
 	name string,
 	timestamp time.Time,
 	duration time.Duration,
+	httpMethod string,
+	url string,
 	responseCode string,
 	success bool) Telemetry {
 
@@ -59,12 +60,14 @@ func NewRequestTelemetry(
 		Context:   NewItemTelemetryContext(),
 		TypeName:  "Request",
 		Data: &RequestData{
-			Id:           uuid.NewV4().String(),
+			Id:           id,
 			Name:         name,
 			StartTime:    timestamp.Format(time.RFC3339Nano),
 			Duration:     formatDuration(duration),
 			ResponseCode: responseCode,
 			Success:      success,
+			HttpMethod:   httpMethod,
+			Url:          url,
 			Ver:          2}}
 }
 

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -71,6 +71,52 @@ func NewRequestTelemetry(
 			Ver:          2}}
 }
 
+func NewRemoteDependencyData(
+	id string,
+	name string,
+	resultCode int,
+	commandName string,
+	kind DataPointType,
+	duration time.Duration,
+	count int,
+	min float32,
+	max float32,
+	stdDev float32,
+	theType string,
+	dependencyKind DependencyKind,
+	success bool,
+	async bool,
+	dependencySource DependencySourceType,
+	properties map[string]string,
+	alterTelementryContext func(*TelemetryContext)) Telemetry {
+
+	context := NewItemTelemetryContext()
+	alterTelementryContext(&context)
+
+	return Telemetry{
+		Timestamp: time.Now(),
+		Context:   context,
+		TypeName:  "RemoteDependency",
+		Data: &RemoteDependencyData{
+			Ver:              2,
+			Id:               id,
+			Name:             name,
+			ResultCode:       resultCode,
+			CommandName:      commandName,
+			Kind:             kind,
+			Duration:         formatDuration(duration),
+			Count:            count,
+			Min:              min,
+			Max:              max,
+			StdDev:           stdDev,
+			Type:             theType,
+			DependencyKind:   dependencyKind,
+			Success:          success,
+			Async:            async,
+			DependencySource: dependencySource,
+			Properties:       properties}}
+}
+
 func formatDuration(duration time.Duration) string {
 	var (
 		refHours   = int(duration.Hours())

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -15,10 +15,15 @@ type Telemetry struct {
 func NewTraceTelemetry(
 	message string,
 	properties map[string]string,
-	severityLevel SeverityLevel) Telemetry {
+	severityLevel SeverityLevel,
+	alterTelementryContext func(*TelemetryContext)) Telemetry {
+
+	context := NewItemTelemetryContext()
+	alterTelementryContext(&context)
+
 	return Telemetry{
 		Timestamp: time.Now(),
-		Context:   NewItemTelemetryContext(),
+		Context:   context,
 		TypeName:  "Message",
 		Data: &MessageData{
 			Message:       message,
@@ -58,11 +63,16 @@ func NewRequestTelemetry(
 	httpMethod string,
 	url string,
 	responseCode string,
-	success bool) Telemetry {
+	success bool,
+	properties map[string]string,
+	alterTelementryContext func(*TelemetryContext)) Telemetry {
+
+	context := NewItemTelemetryContext()
+	alterTelementryContext(&context)
 
 	return Telemetry{
 		Timestamp: time.Now(),
-		Context:   NewItemTelemetryContext(),
+		Context:   context,
 		TypeName:  "Request",
 		Data: &RequestData{
 			Id:           id,
@@ -73,6 +83,7 @@ func NewRequestTelemetry(
 			Success:      success,
 			HttpMethod:   httpMethod,
 			Url:          url,
+			Properties:   properties,
 			Ver:          2}}
 }
 

--- a/appinsights/datacontracts.go
+++ b/appinsights/datacontracts.go
@@ -12,14 +12,19 @@ type Telemetry struct {
 	Data      interface{}
 }
 
-func NewTraceTelemetry(message string, severityLevel SeverityLevel) Telemetry {
+func NewTraceTelemetry(
+	message string,
+	properties map[string]string,
+	severityLevel SeverityLevel) Telemetry {
 	return Telemetry{
 		Timestamp: time.Now(),
 		Context:   NewItemTelemetryContext(),
 		TypeName:  "Message",
 		Data: &MessageData{
-			Message: message,
-			Ver:     2}}
+			Message:       message,
+			Properties:    properties,
+			SeverityLevel: severityLevel,
+			Ver:           2}}
 }
 
 func NewEventTelemetry(name string) Telemetry {

--- a/appinsights/inmemorychannel.go
+++ b/appinsights/inmemorychannel.go
@@ -16,6 +16,7 @@ type TelemetryBufferItems []Telemetry
 type InMemoryChannel interface {
 	EndpointAddress() string
 	Send(Telemetry)
+	Flush()
 }
 
 type inMemoryChannel struct {
@@ -40,9 +41,9 @@ func NewInMemoryChannel(endpointAddress string) InMemoryChannel {
 	}
 
 	go func() {
-		for t := range ticker.C {
+		for _ = range ticker.C {
 			//log.Trace("Transmit tick at ", t)
-			channel.transmit(t)
+			channel.Flush()
 		}
 	}()
 
@@ -74,7 +75,7 @@ func (channel *inMemoryChannel) swapBuffer() TelemetryBufferItems {
 	return buffer
 }
 
-func (channel *inMemoryChannel) transmit(t time.Time) {
+func (channel *inMemoryChannel) Flush() {
 	if len(channel.buffer) == 0 {
 		//log.Trace("Not transmitting due to empty buffer.")
 		return

--- a/appinsights/jsonserializer.go
+++ b/appinsights/jsonserializer.go
@@ -18,21 +18,14 @@ func (items TelemetryBufferItems) serialize() string {
 }
 
 func serialize(item Telemetry) string {
-	data := &data{
-		BaseType: item.baseTypeName() + "Data",
-		BaseData: item.baseData(),
-	}
-
-	context := item.Context()
-
-	envelope := &envelope{
-		Name: "Microsoft.ApplicationInsights." + item.baseTypeName(),
-		Time: item.Timestamp().Format(time.RFC3339),
-		IKey: context.InstrumentationKey(),
-		Data: data,
-	}
-
-	envelope.Tags = context.(*telemetryContext).tags
+	envelope := Envelope{
+		Name: "Microsoft.ApplicationInsights." + item.TypeName,
+		Time: item.Timestamp.Format(time.RFC3339),
+		IKey: item.Context.InstrumentationKey,
+		Data: Data{
+			BaseType: item.TypeName + "Data",
+			BaseData: item.Data},
+		Tags: item.Context.Tags}
 
 	jsonBytes, err := json.Marshal(envelope)
 	if err != nil {

--- a/appinsights/jsonserializer_test.go
+++ b/appinsights/jsonserializer_test.go
@@ -6,7 +6,7 @@ import "time"
 
 func TestJsonSerializerSingle(t *testing.T) {
 
-	item := NewTraceTelemetry("testing", nil, Verbose)
+	item := NewTraceTelemetry("testing", nil, Verbose, func(*TelemetryContext) {})
 	now := time.Now()
 	item.Timestamp = now
 
@@ -24,7 +24,7 @@ func TestJsonSerializerMultiple(t *testing.T) {
 	nowString := now.Format(time.RFC3339)
 
 	for i := 0; i < 3; i++ {
-		item := NewTraceTelemetry("testing", nil, Verbose)
+		item := NewTraceTelemetry("testing", nil, Verbose, func(*TelemetryContext) {})
 		item.Timestamp = now
 		buffer = append(buffer, item)
 	}

--- a/appinsights/jsonserializer_test.go
+++ b/appinsights/jsonserializer_test.go
@@ -6,7 +6,7 @@ import "time"
 
 func TestJsonSerializerSingle(t *testing.T) {
 
-	item := NewTraceTelemetry("testing", Verbose)
+	item := NewTraceTelemetry("testing", nil, Verbose)
 	now := time.Now()
 	item.Timestamp = now
 
@@ -24,7 +24,7 @@ func TestJsonSerializerMultiple(t *testing.T) {
 	nowString := now.Format(time.RFC3339)
 
 	for i := 0; i < 3; i++ {
-		item := NewTraceTelemetry("testing", Verbose)
+		item := NewTraceTelemetry("testing", nil, Verbose)
 		item.Timestamp = now
 		buffer = append(buffer, item)
 	}

--- a/appinsights/jsonserializer_test.go
+++ b/appinsights/jsonserializer_test.go
@@ -8,7 +8,7 @@ func TestJsonSerializerSingle(t *testing.T) {
 
 	item := NewTraceTelemetry("testing", Verbose)
 	now := time.Now()
-	item.timestamp = now
+	item.Timestamp = now
 
 	want := fmt.Sprintf(`{"name":"Microsoft.ApplicationInsights.Message","time":"%s","iKey":"","tags":{},"data":{"baseType":"MessageData","baseData":{"ver":2,"properties":null,"message":"testing","severityLevel":0}}}`, now.Format(time.RFC3339))
 	result := serialize(item)
@@ -25,7 +25,7 @@ func TestJsonSerializerMultiple(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		item := NewTraceTelemetry("testing", Verbose)
-		item.timestamp = now
+		item.Timestamp = now
 		buffer = append(buffer, item)
 	}
 

--- a/appinsights/telemetrychannel.go
+++ b/appinsights/telemetrychannel.go
@@ -2,4 +2,5 @@ package appinsights
 
 type TelemetryChannel interface {
 	Send(Telemetry)
+	Flush()
 }

--- a/appinsights/telemetrycontext.go
+++ b/appinsights/telemetrycontext.go
@@ -1,48 +1,39 @@
 package appinsights
 
-import "os"
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
 
-type TelemetryContext interface {
-	InstrumentationKey() string
-	loadDeviceContext()
-}
-
-type telemetryContext struct {
-	iKey string
-	tags map[string]string
+type TelemetryContext struct {
+	InstrumentationKey string
+	Tags               map[string]string
 }
 
 func NewItemTelemetryContext() TelemetryContext {
-	context := &telemetryContext{
-		tags: make(map[string]string),
-	}
-	return context
+	return TelemetryContext{
+		Tags: make(map[string]string)}
 }
 
 func NewClientTelemetryContext() TelemetryContext {
-	context := &telemetryContext{
-		tags: make(map[string]string),
+	context := TelemetryContext{
+		Tags: make(map[string]string),
 	}
-	context.loadDeviceContext()
-	context.loadInternalContext()
+	loadDeviceContext(&context)
+	loadInternalContext(&context)
 	return context
 }
 
-func (context *telemetryContext) InstrumentationKey() string {
-	return context.iKey
-}
-
-func (context *telemetryContext) loadDeviceContext() {
+func loadDeviceContext(context *TelemetryContext) {
 	hostname, err := os.Hostname()
 	if err == nil {
-		context.tags[DeviceId] = hostname
-		context.tags[DeviceMachineName] = hostname
-		context.tags[DeviceRoleInstance] = hostname
+		context.Tags[DeviceId] = hostname
+		context.Tags[DeviceMachineName] = hostname
+		context.Tags[DeviceRoleInstance] = hostname
 	}
-	context.tags[DeviceOS] = runtime.GOOS
+	context.Tags[DeviceOS] = runtime.GOOS
 }
 
-func (context *telemetryContext) loadInternalContext() {
-	context.tags[InternalSdkVersion] = "go:" + version
+func loadInternalContext(context *TelemetryContext) {
+	context.Tags[InternalSdkVersion] = "go:" + version
 }

--- a/appinsights/version.go
+++ b/appinsights/version.go
@@ -1,3 +1,3 @@
 package appinsights
 
-const version string = "0.1.0"
+const version string = "0.1.0+fdc-1"


### PR DESCRIPTION
`TrackRequest()` now creates an ID and sends the duration in the format that is suggested by the Application Insights server that I use.

Please comment and/or merge.

Thanks!

Cheers,
Stefan