### PR TITLE
Merge develop to master (0.4.1)

### DIFF
--- a/appinsights/exception.go
+++ b/appinsights/exception.go
@@ -12,8 +12,8 @@ import (
 // Exception telemetry items represent a handled or unhandled exceptions that
 // occurred during execution of the monitored application.
 type ExceptionTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Panic message: string, error, or Stringer
 	Error interface{}
@@ -38,12 +38,12 @@ func newExceptionTelemetry(err interface{}, skip int) *ExceptionTelemetry {
 		Error:         err,
 		Frames:        GetCallstack(2 + skip),
 		SeverityLevel: Error,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}

--- a/appinsights/exception.go
+++ b/appinsights/exception.go
@@ -12,7 +12,8 @@ import (
 // Exception telemetry items represent a handled or unhandled exceptions that
 // occurred during execution of the monitored application.
 type ExceptionTelemetry struct {
-	BaseTelemetry
+	baseTelemetry
+	baseTelemetryMeasurements
 
 	// Panic message: string, error, or Stringer
 	Error interface{}
@@ -37,10 +38,12 @@ func newExceptionTelemetry(err interface{}, skip int) *ExceptionTelemetry {
 		Error:         err,
 		Frames:        GetCallstack(2 + skip),
 		SeverityLevel: Error,
-		BaseTelemetry: BaseTelemetry{
-			Timestamp:    currentClock.Now(),
-			Tags:         make(contracts.ContextTags),
-			Properties:   make(map[string]string),
+		baseTelemetry: baseTelemetry{
+			Timestamp:  currentClock.Now(),
+			Tags:       make(contracts.ContextTags),
+			Properties: make(map[string]string),
+		},
+		baseTelemetryMeasurements: baseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}

--- a/appinsights/package.go
+++ b/appinsights/package.go
@@ -4,5 +4,5 @@ package appinsights
 
 const (
 	sdkName = "go"
-	Version = "0.4.0"
+	Version = "0.4.1"
 )

--- a/appinsights/telemetry.go
+++ b/appinsights/telemetry.go
@@ -24,6 +24,9 @@ type Telemetry interface {
 	// Gets the time when this item was measured
 	Time() time.Time
 
+	// Sets the timestamp to the specified time.
+	SetTime(time.Time)
+
 	// Gets context data containing extra, optional tags.  Overrides
 	// values found on client TelemetryContext.
 	ContextTags() map[string]string
@@ -66,6 +69,11 @@ type BaseTelemetryNoMeasurements struct {
 // Time returns the timestamp when this was measured.
 func (item *BaseTelemetry) Time() time.Time {
 	return item.Timestamp
+}
+
+// SetTime sets the timestamp to the specified time.
+func (item *BaseTelemetry) SetTime(t time.Time) {
+	item.Timestamp = t
 }
 
 // Gets context data containing extra, optional tags.  Overrides values

--- a/appinsights/telemetry.go
+++ b/appinsights/telemetry.go
@@ -39,8 +39,8 @@ type Telemetry interface {
 	GetMeasurements() map[string]float64
 }
 
-// Common base struct for telemetry items.
-type baseTelemetry struct {
+// BaseTelemetry is the common base struct for telemetry items.
+type BaseTelemetry struct {
 	// The time this when this item was measured
 	Timestamp time.Time
 
@@ -51,47 +51,49 @@ type baseTelemetry struct {
 	Tags contracts.ContextTags
 }
 
-// Mixin type for telemetry that includes Measurements.
-type baseTelemetryMeasurements struct {
+// BaseTelemetryMeasurements provides the Measurements field for telemetry
+// items that support it.
+type BaseTelemetryMeasurements struct {
 	// Custom measurements
 	Measurements map[string]float64
 }
 
-// Mixin type for telemetry that omits Measurements.
-type baseTelemetryNoMeasurements struct {
+// BaseTelemetryNoMeasurements provides no Measurements field for telemetry
+// items that omit it.
+type BaseTelemetryNoMeasurements struct {
 }
 
-// Gets the time when this item was measured
-func (item *baseTelemetry) Time() time.Time {
+// Time returns the timestamp when this was measured.
+func (item *BaseTelemetry) Time() time.Time {
 	return item.Timestamp
 }
 
 // Gets context data containing extra, optional tags.  Overrides values
 // found on client TelemetryContext.
-func (item *baseTelemetry) ContextTags() map[string]string {
+func (item *BaseTelemetry) ContextTags() map[string]string {
 	return item.Tags
 }
 
 // Gets custom properties to submit with the telemetry item.
-func (item *baseTelemetry) GetProperties() map[string]string {
+func (item *BaseTelemetry) GetProperties() map[string]string {
 	return item.Properties
 }
 
 // Gets custom measurements to submit with the telemetry item.
-func (item *baseTelemetryMeasurements) GetMeasurements() map[string]float64 {
+func (item *BaseTelemetryMeasurements) GetMeasurements() map[string]float64 {
 	return item.Measurements
 }
 
 // GetMeasurements returns nil for telemetry items that do not support measurements.
-func (item *baseTelemetryNoMeasurements) GetMeasurements() map[string]float64 {
+func (item *BaseTelemetryNoMeasurements) GetMeasurements() map[string]float64 {
 	return nil
 }
 
 // Trace telemetry items represent printf-like trace statements that can be
 // text searched.
 type TraceTelemetry struct {
-	baseTelemetry
-	baseTelemetryNoMeasurements
+	BaseTelemetry
+	BaseTelemetryNoMeasurements
 
 	// Trace message
 	Message string
@@ -106,7 +108,7 @@ func NewTraceTelemetry(message string, severityLevel contracts.SeverityLevel) *T
 	return &TraceTelemetry{
 		Message:       message,
 		SeverityLevel: severityLevel,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
@@ -125,8 +127,8 @@ func (trace *TraceTelemetry) TelemetryData() TelemetryData {
 
 // Event telemetry items represent structured event records.
 type EventTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Event name
 	Name string
@@ -136,12 +138,12 @@ type EventTelemetry struct {
 func NewEventTelemetry(name string) *EventTelemetry {
 	return &EventTelemetry{
 		Name: name,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}
@@ -158,8 +160,8 @@ func (event *EventTelemetry) TelemetryData() TelemetryData {
 
 // Metric telemetry items each represent a single data point.
 type MetricTelemetry struct {
-	baseTelemetry
-	baseTelemetryNoMeasurements
+	BaseTelemetry
+	BaseTelemetryNoMeasurements
 
 	// Metric name
 	Name string
@@ -173,7 +175,7 @@ func NewMetricTelemetry(name string, value float64) *MetricTelemetry {
 	return &MetricTelemetry{
 		Name:  name,
 		Value: value,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
@@ -199,8 +201,8 @@ func (metric *MetricTelemetry) TelemetryData() TelemetryData {
 // over time. These values can be calculated by the caller or with the AddData
 // function.
 type AggregateMetricTelemetry struct {
-	baseTelemetry
-	baseTelemetryNoMeasurements
+	BaseTelemetry
+	BaseTelemetryNoMeasurements
 
 	// Metric name
 	Name string
@@ -232,7 +234,7 @@ func NewAggregateMetricTelemetry(name string) *AggregateMetricTelemetry {
 	return &AggregateMetricTelemetry{
 		Name:  name,
 		Count: 0,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
@@ -340,8 +342,8 @@ func (agg *AggregateMetricTelemetry) TelemetryData() TelemetryData {
 // Request telemetry items represents completion of an external request to the
 // application and contains a summary of that request execution and results.
 type RequestTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Identifier of a request call instance. Used for correlation between request
 	// and other telemetry items.
@@ -402,12 +404,12 @@ func NewRequestTelemetry(method, uri string, duration time.Duration, responseCod
 		Duration:     duration,
 		ResponseCode: responseCode,
 		Success:      success,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now().Add(-duration),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}
@@ -443,8 +445,8 @@ func (request *RequestTelemetry) TelemetryData() TelemetryData {
 // Remote dependency telemetry items represent interactions of the monitored
 // component with a remote component/service like SQL or an HTTP endpoint.
 type RemoteDependencyTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Name of the command that initiated this dependency call. Low cardinality
 	// value. Examples are stored procedure name and URL path template.
@@ -484,12 +486,12 @@ func NewRemoteDependencyTelemetry(name, dependencyType, target string, success b
 		Type:    dependencyType,
 		Target:  target,
 		Success: success,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}
@@ -521,8 +523,8 @@ func (telem *RemoteDependencyTelemetry) TelemetryData() TelemetryData {
 // Avaibility telemetry items represent the result of executing an availability
 // test.
 type AvailabilityTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Identifier of a test run. Used to correlate steps of test run and
 	// telemetry generated by the service.
@@ -551,12 +553,12 @@ func NewAvailabilityTelemetry(name string, duration time.Duration, success bool)
 		Name:     name,
 		Duration: duration,
 		Success:  success,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}
@@ -586,8 +588,8 @@ func (telem *AvailabilityTelemetry) TelemetryData() TelemetryData {
 // Page view telemetry items represent generic actions on a page like a button
 // click.
 type PageViewTelemetry struct {
-	baseTelemetry
-	baseTelemetryMeasurements
+	BaseTelemetry
+	BaseTelemetryMeasurements
 
 	// Request URL with all query string parameters
 	Url string
@@ -604,12 +606,12 @@ func NewPageViewTelemetry(name, url string) *PageViewTelemetry {
 	return &PageViewTelemetry{
 		Name: name,
 		Url:  url,
-		baseTelemetry: baseTelemetry{
+		BaseTelemetry: BaseTelemetry{
 			Timestamp:  currentClock.Now(),
 			Tags:       make(contracts.ContextTags),
 			Properties: make(map[string]string),
 		},
-		baseTelemetryMeasurements: baseTelemetryMeasurements{
+		BaseTelemetryMeasurements: BaseTelemetryMeasurements{
 			Measurements: make(map[string]float64),
 		},
 	}

--- a/appinsights/telemetry.go
+++ b/appinsights/telemetry.go
@@ -51,11 +51,13 @@ type baseTelemetry struct {
 	Tags contracts.ContextTags
 }
 
+// Mixin type for telemetry that includes Measurements.
 type baseTelemetryMeasurements struct {
 	// Custom measurements
 	Measurements map[string]float64
 }
 
+// Mixin type for telemetry that omits Measurements.
 type baseTelemetryNoMeasurements struct {
 }
 

--- a/appinsights/telemetry_test.go
+++ b/appinsights/telemetry_test.go
@@ -59,6 +59,11 @@ func TestTraceTelemetry(t *testing.T) {
 
 	checkDataContract(t, "Message", d2.Message, "~my-2nd-message~")
 	checkDataContract(t, "SeverityLevel", d2.SeverityLevel, Critical)
+
+	var telemInterface Telemetry
+	if telemInterface = telem; telemInterface.GetMeasurements() != nil {
+		t.Errorf("Trace.(Telemetry).GetMeasurements should return nil")
+	}
 }
 
 func TestEventTelemetry(t *testing.T) {
@@ -118,6 +123,11 @@ func TestMetricTelemetry(t *testing.T) {
 	checkDataContract(t, "DataPoint.Value", dp2.Value, 5678.0)
 	checkDataContract(t, "DataPoint.Kind", dp2.Kind, Measurement)
 	checkDataContract(t, "DataPoint.Count", dp2.Count, 1)
+
+	var telemInterface Telemetry
+	if telemInterface = telem; telemInterface.GetMeasurements() != nil {
+		t.Errorf("Metric.(Telemetry).GetMeasurements should return nil")
+	}
 }
 
 type statsTest struct {

--- a/appinsights/telemetrycontext.go
+++ b/appinsights/telemetrycontext.go
@@ -64,7 +64,7 @@ func (context *TelemetryContext) envelop(item Telemetry) *contracts.Envelope {
 		timestamp = currentClock.Now()
 	}
 
-	envelope.Time = timestamp.UTC().Format(time.RFC3339)
+	envelope.Time = timestamp.UTC().Format(time.RFC3339Nano)
 
 	if contextTags := item.ContextTags(); contextTags != nil {
 		envelope.Tags = contextTags

--- a/appinsights/telemetrycontext_test.go
+++ b/appinsights/telemetrycontext_test.go
@@ -3,6 +3,7 @@ package appinsights
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Microsoft/ApplicationInsights-Go/appinsights/contracts"
 )
@@ -130,5 +131,15 @@ func TestSanitize(t *testing.T) {
 
 	if v, ok := evdata.Measurements[name[:150]]; !ok || v != 55.0 {
 		t.Error("Event measurement name was not truncated")
+	}
+}
+
+func TestTimestamp(t *testing.T) {
+	ev := NewEventTelemetry("event")
+	ev.Timestamp = time.Unix(1523667421, 500000000)
+
+	envelope := NewTelemetryContext().envelop(ev)
+	if envelope.Time != "2018-04-14T00:57:01.5Z" {
+		t.Errorf("Unexpected timestamp: %s", envelope.Time)
 	}
 }

--- a/appinsights/transmitter_test.go
+++ b/appinsights/transmitter_test.go
@@ -425,6 +425,9 @@ func TestTransmitResults(t *testing.T) {
 }
 
 func TestGetRetryItems(t *testing.T) {
+	mockClock()
+	defer resetClock()
+
 	// Keep a pristine copy.
 	originalPayload, originalItems := makePayload()
 


### PR DESCRIPTION
* Increase precision of telemetry timestamps to nanoseconds.  It was previously seconds.
* Remove `Measurements` field from telemetry types that do not support it.  These fields were previously ignored and always `nil`.
* Add `SetTime()` to `Telemetry` interface.
* Rev to 0.4.1