### PR TITLE
update default timestamp format to RFC3339Nano

### DIFF
--- a/appinsights/telemetrycontext.go
+++ b/appinsights/telemetrycontext.go
@@ -64,7 +64,7 @@ func (context *TelemetryContext) envelop(item Telemetry) *contracts.Envelope {
 		timestamp = currentClock.Now()
 	}
 
-	envelope.Time = timestamp.UTC().Format(time.RFC3339)
+	envelope.Time = timestamp.UTC().Format(time.RFC3339Nano)
 
 	if contextTags := item.ContextTags(); contextTags != nil {
 		envelope.Tags = contextTags


### PR DESCRIPTION
Fix #15 .
Update the current timestamp format from RFC3339 to RFC3339Nano.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
