### PR TITLE
Switch to gofrs/uuid

### DIFF
--- a/appinsights/uuid.go
+++ b/appinsights/uuid.go
@@ -51,8 +51,6 @@ func (gen *uuidGenerator) newUUID() uuid.UUID {
 	//err will be either EOF or unexpected EOF
 	if err != nil {
 		gen.fallback(&u)
-		u.SetVersion(uuid.V4)
-		u.SetVariant(uuid.VariantRFC4122)
 	}
 
 	return u
@@ -64,6 +62,8 @@ func (gen *uuidGenerator) fallback(u *uuid.UUID) {
 	defer gen.Unlock()
 	// This does not fail as per documentation
 	gen.fallbackRand.Read(u[:])
+	u.SetVersion(uuid.V4)
+	u.SetVariant(uuid.VariantRFC4122)
 }
 
 // newUUID generates a new V4 UUID

--- a/appinsights/uuid.go
+++ b/appinsights/uuid.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
-// uuidGenerator is a wrapper for satori/go.uuid, used for a few reasons:
+// uuidGenerator is a wrapper for gofrs/uuid, an active fork of satori/go.uuid used for a few reasons:
 //   - Avoids build failures due to version differences when a project imports us but
 //     does not respect our vendoring. (satori/go.uuid#77, #71, #66, ...)
 //   - Avoids error output when creaing new UUID's: if the crypto reader fails,

--- a/appinsights/uuid.go
+++ b/appinsights/uuid.go
@@ -46,13 +46,15 @@ func newUuidGenerator(reader io.Reader) *uuidGenerator {
 
 // newUUID generates a new V4 UUID
 func (gen *uuidGenerator) newUUID() uuid.UUID {
-	u := uuid.UUID{}
-	if _, err := io.ReadFull(gen.reader, u[:]); err != nil {
+	//call the standard generator
+	u, err := uuid.NewV4()
+	//err will be either EOF or unexpected EOF
+	if err != nil {
 		gen.fallback(&u)
+		u.SetVersion(uuid.V4)
+		u.SetVariant(uuid.VariantRFC4122)
 	}
 
-	u.SetVersion(uuid.V4)
-	u.SetVersion(uuid.VariantRFC4122)
 	return u
 }
 
@@ -60,7 +62,6 @@ func (gen *uuidGenerator) newUUID() uuid.UUID {
 func (gen *uuidGenerator) fallback(u *uuid.UUID) {
 	gen.Lock()
 	defer gen.Unlock()
-
 	// This does not fail as per documentation
 	gen.fallbackRand.Read(u[:])
 }

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.12
 
 require (
 	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c
+	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/satori/go.uuid v1.2.0
 	github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,9 @@ code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c h1:5eeuG0BHx1+DHe
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gofrs/uuid v1.2.0 h1:coDhrjgyJaglxSjxuJdqQSSdUpG3w6p1OwN2od6frBU=
+github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=


### PR DESCRIPTION
This is to fix [WS-2018-0594](https://www.whitesourcesoftware.com/vulnerability-database/WS-2018-0594).
[Satori/go.uuid](https://github.com/satori/go.uuid) doesn't seem to be maintained. However, there is a fork repo, [gofrs/uuid](https://github.com/gofrs/uuid) which is being well-maintained. Aks-engine folks have done this as well.


Fix https://github.com/microsoft/ApplicationInsights-Go/issues/51 .


For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
