### PR TITLE
Installation capability is removed from go get. Need to use go instal…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We’re constantly assessing opportunities to expand our support for other langu
 ## Requirements
 **Install**
 ```
-go get github.com/microsoft/ApplicationInsights-Go/appinsights
+go install github.com/microsoft/ApplicationInsights-Go/appinsights
 ```
 **Get an instrumentation key**
 >**Note**: an instrumentation key is required before any data can be sent. Please see the "[Getting an Application Insights Instrumentation Key](https://github.com/microsoft/AppInsights-Home/wiki#getting-an-application-insights-instrumentation-key)" section of the wiki for more information. To try the SDK without an instrumentation key, set the instrumentationKey config value to a non-empty string.


### PR DESCRIPTION
…l instead.

"Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead."
Source: https://golang.org/doc/go-get-install-deprecation

The -i flag for go install is also deprecated and go install is enough.

Tested with go1.17.2



For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [x ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
